### PR TITLE
Easy class methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    locations_ng (0.0.4)
+    locations_ng (0.0.5)
       rails (= 4.2.6)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require 'locations_ng'
 
 ### 1. Get all States, canonical
 ```ruby
-LocationsNg::State.new.all
+LocationsNg::State.all
 ```
 #### Response
 ```json
@@ -52,7 +52,7 @@ LocationsNg::State.new.all
 
 ### 2. Get detailed data of a State
 ```ruby
-LocationsNg::State.new.details('Lagos')
+LocationsNg::State.details('Lagos')
 ```
 #### Response
 ```json
@@ -77,7 +77,7 @@ LocationsNg::State.new.details('Lagos')
 
 ### 3. Get State capital
 ```ruby
-LocationsNg::State.new.capital('Lagos')
+LocationsNg::State.capital('Lagos')
 ```
 #### Response
 ```json
@@ -86,7 +86,7 @@ Ikeja
 
 ### 4. Get all Cities
 ```ruby
-LocationsNg::City.new.all
+LocationsNg::City.all
 ```
 #### Response
 ```json
@@ -113,7 +113,7 @@ LocationsNg::City.new.all
 
 ### 5. Get Cities in a State
 ```ruby
-LocationsNg::City.new.cities('Akwa Ibom')
+LocationsNg::City.cities('Akwa Ibom')
 ```
 #### Response
 ```json
@@ -122,7 +122,7 @@ LocationsNg::City.new.cities('Akwa Ibom')
 
 ### 6. Get all LGAs
 ```ruby
-LocationsNg::Lga.new.all
+LocationsNg::Lga.all
 ```
 #### Response
 ```json
@@ -184,7 +184,7 @@ LocationsNg::Lga.new.all
 
 ### 7. Get LGAs in a State
 ```ruby
-LocationsNg::Lga.new.lgas('Lagos')
+LocationsNg::Lga.lgas('Lagos')
 ```
 #### Response
 ```json

--- a/lib/locations_ng/city.rb
+++ b/lib/locations_ng/city.rb
@@ -1,10 +1,10 @@
 module LocationsNg
   class City
-    def all
+    def self.all
       load_cities
     end
 
-    def cities(state)
+    def self.cities(state)
       state = state.downcase.gsub(' ', '_')
       all_cities = load_cities
 
@@ -19,11 +19,11 @@ module LocationsNg
 
     private
 
-    def load_cities
+    def self.load_cities
       YAML.load(File.read(files_location 'cities'))
     end
 
-    def files_location(file)
+    def self.files_location(file)
       File.expand_path("../locations/#{file}.yml", __FILE__)
     end
   end

--- a/lib/locations_ng/lga.rb
+++ b/lib/locations_ng/lga.rb
@@ -1,10 +1,10 @@
 module LocationsNg
   class Lga
-    def all
+    def self.all
       load_lgas
     end
 
-    def lgas(state)
+    def self.lgas(state)
       state = state.downcase.gsub(' ', '_')
       all_lgas = load_lgas
 
@@ -19,11 +19,11 @@ module LocationsNg
 
     private
 
-    def load_lgas
+    def self.load_lgas
       YAML.load(File.read(files_location 'lgas'))
     end
 
-    def files_location(file)
+    def self.files_location(file)
       File.expand_path("../locations/#{file}.yml", __FILE__)
     end
   end

--- a/lib/locations_ng/state.rb
+++ b/lib/locations_ng/state.rb
@@ -1,10 +1,10 @@
 module LocationsNg
   class State
-    def all
+    def self.all
       load_states.map{ |s| {name: s['name'], capital: s['capital']} }
     end
 
-    def details(state)
+    def self.details(state)
       state = state.downcase.gsub(' ', '_')
       all_states = load_states
 
@@ -20,7 +20,7 @@ module LocationsNg
       end
     end
 
-    def capital(state)
+    def self.capital(state)
       state = state.downcase.gsub(' ', '_')
       all_states = load_states
 
@@ -35,11 +35,11 @@ module LocationsNg
 
     private
 
-    def load_states
+    def self.load_states
       YAML.load(File.read(files_location 'states'))
     end
 
-    def files_location(file)
+    def self.files_location(file)
       File.expand_path("../locations/#{file}.yml", __FILE__)
     end
   end

--- a/lib/locations_ng/state.rb
+++ b/lib/locations_ng/state.rb
@@ -15,7 +15,7 @@ module LocationsNg
       else
         res = all_states[state_index].with_indifferent_access
         res['cities'] = LocationsNg::City.new.cities(state)
-        res['lgas'] = LocationsNg::Lga.new.lgas(state)
+        res['lgas'] = LocationsNg::Lga.lgas(state)
         res
       end
     end

--- a/lib/locations_ng/state.rb
+++ b/lib/locations_ng/state.rb
@@ -14,7 +14,7 @@ module LocationsNg
         {message: "No state found for '#{state}'", status: 404}
       else
         res = all_states[state_index].with_indifferent_access
-        res['cities'] = LocationsNg::City.new.cities(state)
+        res['cities'] = LocationsNg::City.cities(state)
         res['lgas'] = LocationsNg::Lga.lgas(state)
         res
       end

--- a/spec/locations_ng/city_spec.rb
+++ b/spec/locations_ng/city_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module LocationsNg
   describe City do
-    let(:city) { LocationsNg::City.new }
+    let(:city) { LocationsNg::City }
 
     describe '.all' do
       let(:cities_response) { File.read('spec/responses/cities.json') }

--- a/spec/locations_ng/lga_spec.rb
+++ b/spec/locations_ng/lga_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module LocationsNg
   describe Lga do
-    let(:lga) { LocationsNg::Lga.new }
+    let(:lga) { LocationsNg::Lga }
 
     describe '.all' do
       let(:lga_response) { File.read('spec/responses/lgas.json') }

--- a/spec/locations_ng/state_spec.rb
+++ b/spec/locations_ng/state_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module LocationsNg
   describe State do
-    let(:state) { LocationsNg::State.new }
+    let(:state) { LocationsNg::State }
 
     describe '.all' do
       let(:state_response) { File.read('spec/responses/canonical_states.json') }


### PR DESCRIPTION
This will enable easy calling of methods without the use of the `new` keyword. So, `LocationsNg::State.new.all` will become `LocationsNg::State.all` and etc...