### PR TITLE
Make state name consistent

### DIFF
--- a/lib/locations_ng/locations/lgas.yml
+++ b/lib/locations_ng/locations/lgas.yml
@@ -676,7 +676,7 @@
     - NGURORE
     - TOUNGO
     - YOLDE KOHI
-- state: Akwa-ibom
+- state: Akwa Ibom
   state_alias: akwa-ibom
   lgas:
   - Abak
@@ -4758,7 +4758,7 @@
     - Ukpata
     - Umulokpa
     - Uvuru
-- state: Fct
+- state: Federal Capital Territory
   state_alias: fct
   lgas:
   - Abaji


### PR DESCRIPTION
This would make the name of Akwa Ibom state and the Federal Capital Territory consistent. Which is important if a user wants to fetch a list of LGAs depending on a preselected state (using the name of the state).